### PR TITLE
Reset background color when restarting game

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -250,6 +250,7 @@ export class Game {
     this.rightDoorClosed = false;
     this.doorTargetsY.left = 4.2;
     this.doorTargetsY.right = 4.2;
+    this.scene.background = new THREE.Color(0x050505);
 
     for (const anim of this.animatronics) {
       this.scene.remove(anim.mesh);


### PR DESCRIPTION
## Summary
- Restore default scene background when the game is reset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0e0bd4b48833088d107533e5ddbf4